### PR TITLE
Dropdown fix

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -98,12 +98,12 @@
                                  src="https://wiki.openstreetmap.org/w/images/7/79/Public-images-osm_logo.svg"/>
                         </a>
                         <a class='btn btn-outline-secondary dropdown-toggle dropdown-toggle-split' data-toggle='dropdown' href="#"></a>
-                        <ul class='dropdown-menu'>
+                        <ul class='dropdown-menu dropdown-menu-right'>
                             <li>
                               <a id="osm-link-edit-id" target="_blank" class="dropdown-item" href="https://www.openstreetmap.org/edit?editor=id">Edytuj ten obszar w iD</a>
                             </li>
                             <li>
-                              <a id="osm-link-edit-remote" target="_blank" class="dropdown-item" href="https://www.openstreetmap.org/edit?editor=remote">Edytuj ten obszar używając zewnętrznego edytora (JOSM, Potlatch, Merkaartor)</a>
+                              <a id="osm-link-edit-remote" target="_blank" class="dropdown-item" href="https://www.openstreetmap.org/edit?editor=remote">Edytuj ten obszar w zewnętrznym edytorze (JOSM, Potlatch, Merkaartor)</a>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
Aktualnie menu rozciąga stronę:
![obraz](https://user-images.githubusercontent.com/16021640/105471347-8a49b900-5c92-11eb-9176-78ea43835890.png)

Po zmianie:
![obraz](https://user-images.githubusercontent.com/16021640/105471393-9897d500-5c92-11eb-839d-d97e5c141acf.png)

+ lekko skrócony tekst
