### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/web/map.js
+++ b/web/map.js
@@ -34,9 +34,7 @@ var map = new mapboxgl.Map({
             "raster-tiles": {
                 "type": "raster",
                 "tiles": [
-                    "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                    "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                    "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                 ],
                 "tileSize": 256,
                 "minzoom": 0,


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one, see

https://github.com/openstreetmap/operations/issues/737

cc: @mskakuj 