### PR TITLE
Mapowanie ulic 08.12.2023

### DIFF
--- a/processing/sql/data/street_names_mappings.csv
+++ b/processing/sql/data/street_names_mappings.csv
@@ -1968,7 +1968,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0918123,00091,gen. Romana Abrahama,Generała Romana Abrahama
 0986283,00091,gen. Romana Abrahama,Generała Romana Abrahama
 0971637,00091,gen. Romana Abrahama,Generała Romana Abrahama
-0931678,31012,gen. Rómmla,Generała Janusza Rómmla
+0931678,31012,gen. Rómmla,Generała Juliusza Rómmla
 0415936,22963,gen. Romualda Traugutta,Generała Romualda Traugutta
 0954120,22963,gen. Romualda Traugutta,Generała Romualda Traugutta
 0920539,22963,gen. Romualda Traugutta,Generała Romualda Traugutta
@@ -2867,7 +2867,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0931945,08056,Karłowicza,Mieczysława Karłowicza
 0974618,08056,Karłowicza,Mieczysława Karłowicza
 0921438,08056,Karłowicza,Mieczysława Karłowicza
-0942765,08056,Karłowicza,Mieczysława Karłowicza
+0942765,08056,Karłowicza,Jana Karłowicza
 0968569,08056,Karłowicza,Mieczysława Karłowicza
 0945232,08056,Karłowicza,Mieczysława Karłowicza
 0945746,08056,Karłowicza,Mieczysława Karłowicza
@@ -3048,7 +3048,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0985444,09000,Kołłątaja,Hugona Kołłątaja
 0928854,09000,Kołłątaja,Hugona Kołłątaja
 0493250,09000,Kołłątaja,Hugona Kołłątaja
-0939409,09000,Kołłątaja,Hugona Kołłątaja
+0939409,09000,Kołłątaja,Hugo Kołłątaja
 0939473,09000,Kołłątaja,Hugona Kołłątaja
 0935400,09000,Kołłątaja,Hugona Kołłątaja
 0965281,09000,Kołłątaja,Hugona Kołłątaja
@@ -4184,7 +4184,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0978929,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
 0209757,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
 0937474,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
-0931678,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
+0931678,09345,ks. Augustyna Kordeckiego,Augustyna Kordeckiego
 0920539,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
 0920806,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
 0954225,09345,ks. Augustyna Kordeckiego,Księdza Augustyna Kordeckiego
@@ -4247,7 +4247,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0071840,49670,ks. bp Albina Małysiaka,Księdza Biskupa Albina Małysiaka
 0945746,55469,ks. bp Alojzego Orszulika,Księdza Biskupa Alojzego Orszulika
 0941286,00685,ks. bp. Bandurskiego,Księdza Biskupa Władysława Bandurskiego
-0942222,31698,ks. bp. Bogedaina,Księdza Biskupa Bernarda Bogedaina
+0942222,31698,ks. bp. Bogedaina,Księdza Biskupa Bogedaina
 0943150,30251,ks. bp. Czesława Domina,Księdza Biskupa Czesława Domina
 0942222,31697,ks. bp. H. Bednorza,Księdza Biskupa Herberta Bednorza
 0940163,00963,ks. bp. Herberta Bednorza,Księdza Biskupa Herberta Bednorza
@@ -4406,7 +4406,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0943902,24960,ks. Franciszka Wyciślika,Księdza Franciszka Wyciślika
 0748840,35506,ks. Frosta,Księdza Zygmunta Frosta
 0496716,05255,ks. Gajdy,Księdza Jana Gajdy
-0135450,05419,ks. Gąski,Księdza Waltera Gąski
+0135450,05419,ks. Gąski,Księdza Gąski
 0942222,29251,ks. gen. Jana Brandysa,Księdza Generała Jana Brandysa
 0983652,44389,ks. gen. W. Kiedrowskiego,Księdza Generała Witolda Kiedrowskiego
 0977404,56893,ks. Generała Bernarda Wituckiego,Księdza Generała Bernarda Wituckiego
@@ -4477,7 +4477,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0928363,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
 0929902,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
 0930868,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
-0931678,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
+0931678,20100,ks. Ignacego Skorupki,Ignacego Skorupki
 0920539,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
 0954225,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
 0921496,20100,ks. Ignacego Skorupki,Księdza Ignacego Skorupki
@@ -4822,7 +4822,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0083204,32298,ks. Juliana Zawadzińskiego,Księdza Juliana Zawadzińskiego
 0160689,42978,ks. Jutrzenki Trzebiatowskiego,Księdza Jutrzenki Trzebiatowskiego
 0828236,37599,ks. Kalinowskiego,Księdza Kazimierza Kalinowskiego
-0926996,44612,ks. kan. Franciszka Pieli,Księdza Kanonika Franciszka Pieli
+0926996,44612,ks. kan. Franciszka Pieli,Księdza kanonika Franciszka Pieli
 0156357,54875,Ks. kan. Franciszka Prussa,Księdza Kanonika Franciszka Prussa
 0846441,49442,ks. kan. Krzysztofa Stanowicza,Księdza Kanonika Krzysztofa Stanowicza
 0970632,41539,ks. kan. Stanisława Sobczaka,Księdza Kanonika Stanisława Sobczaka
@@ -4940,7 +4940,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0845476,30798,ks. Kujawskiego,Księdza Wincentego Kujawskiego
 0849876,10349,ks. Kujota,Księdza Stanisława Kujota
 0982954,51086,Ks. Kujota,Księdza Stanisława Kujota
-0052669,32012,ks. Kukli,Księdza Tadeusza Kukli
+0052669,32012,ks. Kukli,Księdza Kukli
 0501742,10376,ks. Kuliga,Księdza Marka Kuliga
 0934470,39215,ks. Kursikowskiego,Księdza Benona Jerzego Kursikowskiego
 0966984,18283,ks. L. Raczkowskiego,Księdza Leona Raczkowskiego
@@ -5038,7 +5038,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0945380,01805,ks. Norberta Bończyka,Księdza Norberta Bończyka
 0943813,48132,Ks. Norberta Bończyka,Księdza Norberta Bończyka
 0598990,37262,ks. Okońskiego,Księdza Stanisława Okońskiego
-0052669,32013,ks. Olszaka,Księdza Karola Olszaka
+0052669,32013,ks. Olszaka,Księdza Olszaka
 0748840,35507,ks. Omańkowskiego,Księdza Tadeusza Omańkowskiego
 0923472,19755,ks. Ottona Sidorowicza,Księdza Ottona Sidorowicza
 0491593,27502,ks. Ottona Steiera,Księdza Ottona Steiera
@@ -5203,7 +5203,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0950463,28298,ks. Prałata Mariana Łaczka,Księdza Prałata Mariana Łaczka
 0038965,35423,ks. Prałata Michała Badowskiego,Księdza Prałata Michała Badowskiego
 0928363,52634,ks. prałata Romualda Biniaka,Księdza Prałata Romualda Biniaka
-0927642,30109,ks. Prałata Stanisława Słonki,Księdza Prałata Stanisława Słonki
+0927642,30109,ks. Prałata Stanisława Słonki,Księdza Stanisława Słonki
 0928363,49745,ks. Prałata Stefana Brylla,Księdza Prałata Stefana Brylla
 0932057,51495,Ks. Prałata Zdzisława Skrzeka,Księdza Prałata Zdzisława Skrzeka
 0954596,50796,Ks. Prof. Dr Jana Respądka,Księdza Profesora Doktora Jana Respądka
@@ -6527,7 +6527,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0957650,55404,o. Leona Godlewskiego,Ojca Leona Godlewskiego
 0968300,48566,O. M. Kolbe,Ojca Maksymiliana Kolbe
 0057922,43244,o. Maksymiliana,Ojca Maksymiliana
-0944853,08806,o. Maksymiliana Kolbego,Ojca Maksymiliana Kolbego
+0944853,08806,o. Maksymiliana Kolbego,Maksymiliana Marii Kolbego
 0965677,37598,o. Maksymiliana Marii Kolbe,Ojca Maksymiliana Marii Kolbe
 0969400,40383,o. Mariana Żelazka,Ojca Mariana Żelazka
 0342054,42135,o. Pawła Smolikowskiego,Ojca Pawła Smolikowskiego
@@ -11315,7 +11315,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0935802,59073,Plac św. Jana Apostoła,Plac Świętego Jana Apostoła
 0921237,49061,Płk. Ryszarda Kuklińskiego,Pułkownika Ryszarda Kuklińskiego
 0988684,11862,gen. Stanisława Maczka,Generała Stanisława Maczka
-0931678,40255,hm. Tadeusza Sobisia,Hercmistrza Tadeusza Sobisia
+0931678,40255,hm. Tadeusza Sobisia,Tadeusza Sobisia
 0987259,29214,kpt. Konstantego Maciejewicza,Kapitana Konstantego Maciejewicza
 0987259,40832,kpt. Leonida Teligi,Kapitana Leonida Teligi
 0687511,59197,kpt. Wacława Domagały Polkowskiego,Kapitana Wacława Domagały Polkowskiego
@@ -11566,7 +11566,7 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0416781,60719,Aleja  AL. Bukowa,Aleja Bukowa
 0416628,60719,Aleja AL. Bukowa,Aleja Bukowa
 0935127,38806,B. Chrobrego,Bolesława Chrobrego
-0941984,60749,Bł. Ks. J. Popiełuszki,Błogosławionego Księdza Jerzego Popiełuszki
+0941984,60749,Bł. Ks. J. Popiełuszki,Błogosławionego księdza Jerzego Popiełuszki
 0702720,33284,E. Orzeszkowej,Elizy Orzeszkowej
 0941984,60759,Gen. Ziętka,Generała Jerzego Ziętka
 0450230,60669,Ks. Franciszka Gawlika,Księdza Franciszka Gawlika
@@ -11869,3 +11869,194 @@ teryt_simc_code,teryt_ulic_code,teryt_street_name,osm_street_name
 0930868,15760,Blaise Pascala,Blaise'a Pascala
 0212564,59417,Wichrowe wzgórze,Wichrowe Wzgórze
 0943285,48409,marszałka Józefa Piłsudskiego,Marszałka Józefa Piłsudskiego
+0214126,00740,Barcioka,Jana Barcioka
+0939409,01258,Bieli,Teofila Bieli
+0941984,01285,Bieni,Leona Bieni
+0215404,01804,Bończyka,Księdza Norberta Bończyka
+0218963,01804,Bończyka,Norberta Bończyka
+0931862,02120,Broniewskiego,Władysława Broniewskiego
+0213960,02287,Brzozy,Teofila Brzozy
+0939473,03024,Cieplaka,Zygmunta Cieplaka
+0939409,03579,Damrota,Konstantego Damrota
+0214043,03579,Damrota,Konstantego Damrota
+0050950,03623,Darwina,Karola Darwina
+0214391,03623,Darwina,Karola Darwina
+0941984,03667,Dąbrowskiego,Henryka Dąbrowskiego
+0141077,03849,Długosza,Jana Długosza
+0941984,03849,Długosza,Jana Długosza
+0135562,04314,Drzymały,Michała Drzymały
+0941984,04314,Drzymały,Michała Drzymały
+0939409,05213,Furgoła,Piotra Furgoła
+0135272,05237,Gagarina,Jurija Gagarina
+0927091,05954,Osiedle Górne Głębce,Górne Głębce
+0214126,06477,Hallera,Józefa Hallera
+0927091,07287,Osiedle Jarzębata,Jarzębata
+0927091,07691,Osiedle Jurzyków,Jurzyków
+0939409,07851,Kałuży,Wiktora Kałuży
+0142450,08147,Kasprowicza,Jana Kasprowicza
+0144584,08717,Kocha,Roberta Kocha
+0050860,08725,Kochanowskiego,Jana Kochanowskiego
+0926677,08725,Kochanowskiego,Jana Kochanowskiego
+0134657,08725,Kochanowskiego,Jana Kochanowskiego
+0135450,08725,Kochanowskiego,Jana Kochanowskiego
+0931945,08725,Kochanowskiego,Jana Kochanowskiego
+0939409,08725,Kochanowskiego,Jana Kochanowskiego
+0941984,09106,Konarskiego,Stanisława Konarskiego
+0214327,09353,Korfantego,Wojciecha Korfantego
+0221936,09353,Korfantego,Wojciecha Korfantego
+0135450,09353,Korfantego,Wojciecha Korfantego
+0931945,09353,Korfantego,Wojciecha Korfantego
+0932494,09353,Korfantego,Wojciecha Korfantego
+0931862,09572,Kościuszki,Tadeusza Kościuszki
+0927091,09723,Osiedle Kozińce,Kozińce
+0941984,09826,Krasickiego,Jana Krasickiego
+0216533,09826,Krasickiego,Józefa Ignacego Krasickiego
+0941748,09826,Krasickiego,Ignacego Krasickiego
+0133451,09841,Krasińskiego,Zygmunta Krasińskiego
+0135540,09841,Krasińskiego,Zygmunta Krasińskiego
+0218489,09869,Kraszewskiego,Józefa Ignacego Kraszewskiego
+0942765,10793,Joachima Lelewela,Kapitana Joachima Lelewela
+0132196,11246,Lompy,Józefa Lompy
+0130748,11246,Lompy,Józefa Lompy
+0135450,11246,Lompy,Józefa Lompy
+0135510,11246,Lompy,Józefa Lompy
+0135540,11246,Lompy,Józefa Lompy
+0931945,11246,Lompy,Józefa Lompy
+0142208,11246,Lompy,Józefa Lompy
+0146956,11246,Lompy,Józefa Lompy
+0146985,11246,Lompy,Józefa Lompy
+0932494,11246,Lompy,Józefa Lompy
+0941984,11246,Lompy,Józefa Lompy
+0939409,11246,Lompy,Józefa Lompy
+0941984,11947,Majakowskiego,Włodzimierza Majakowskiego
+0941984,12381,Marksa,Andrzeja Marksa
+0939409,12385,Markwioka,Józefa Markwioka
+0214327,12672,Miarki,Karola Miarki
+0214362,12672,Miarki,Karola Miarki
+0944126,12672,Miarki,Karola Miarki
+0135556,12672,Miarki,Karola Miarki
+0931945,12672,Miarki,Karola Miarki
+0941139,12672,Miarki,Karola Miarki
+0941984,12672,Miarki,Karola Miarki
+0218621,12672,Miarki,Karola Miarki
+0218704,12672,Miarki,Karola Miarki
+0215500,12672,Miarki,Karola Miarki
+0215597,12672,Miarki,Karola Miarki
+0218963,12672,Miarki,Karola Miarki
+0213925,12672,Miarki,Karola Miarki
+0939409,12672,Miarki,Karola Miarki
+0219566,12733,Plac Mickiewicza,Plac Adama Mickiewicza
+0942417,12734,Mickiewicza,Adama Mickiewicza
+0931862,12734,Mickiewicza,Adama Mickiewicza
+0941984,12791,Mielęckiego,Andrzeja Mielęckiego
+0050765,13278,Morcinka,Gustawa Morcinka
+0214362,13278,Morcinka,Gustawa Morcinka
+0944126,13278,Morcinka,Gustawa Morcinka
+0941139,13278,Morcinka,Gustawa Morcinka
+0941984,13278,Morcinka,Gustawa Morcinka
+0217461,13278,Morcinka,Gustawa Morcinka
+0942417,13409,Mozarta,Wolfganga Amadeusza Mozarta
+0925258,14499,Nowowiejskiego,Feliksa Nowowiejskiego
+0216929,15529,Ignacego Paderewskiego,Ignacego Jana Paderewskiego
+0945491,15529,Ignacego Paderewskiego,Ignacego Jana Paderewskiego
+0939409,16144,Pierchały,Józefa Pierchały
+0945491,16264,Józefa Piłsudskiego,Marszałka Józefa Piłsudskiego
+0214327,16301,Piontka,Józefa Piontka
+0217679,17100,Poniatowskiego,Stanisława Augusta Poniatowskiego
+0931750,17574,Prusa,Bolesława Prusa
+0144584,17574,Prusa,Bolesława Prusa
+0214327,17574,Prusa,Bolesława Prusa
+0931862,17574,Prusa,Bolesława Prusa
+0147418,17574,Prusa,Bolesława Prusa
+0941139,17574,Prusa,Bolesława Prusa
+0941984,17574,Prusa,Bolesława Prusa
+0218489,17574,Prusa,Bolesława Prusa
+0215440,18885,Rostka,Józefa Rostka
+0138649,19830,Sienkiewicza,Henryka Sienkiewicza
+0931862,19830,Sienkiewicza,Henryka Sienkiewicza
+0926677,19900,Sikorskiego,Generała Władysława Sikorskiego
+0133451,19900,Sikorskiego,Generała Władysława Sikorskiego
+0941984,19900,Sikorskiego,Władysława Sikorskiego
+0215427,19900,Sikorskiego,Władysława Sikorskiego
+0218986,19900,Sikorskiego,Władysława Sikorskiego
+0216361,19900,Sikorskiego,Generała Władysława Sikorskiego
+0213960,20375,Smołki,Emanuela Smołki
+0135450,20421,Sobieskiego,Jana Sobieskiego
+0931945,20421,Sobieskiego,Jana III Sobieskiego
+0216496,20421,Sobieskiego,Jana Sobieskiego
+0216556,20421,Sobieskiego,Jana Sobieskiego
+0939094,20427,Jana Sobieskiego,Jana III Sobieskiego
+0076523,20549,Solskiego,Ludwika Solskiego
+0926996,20551,Ludwika Solskiego,Ludwika Solskiego
+0214327,20765,Stachury,Antoniego Stachury
+0214362,20765,Stachury,Antoniego Stachury
+0925198,20806,Stalmacha,Pawła Stalmacha
+0941984,20806,Stalmacha,Pawła Stalmacha
+0939409,21378,Strzelczyka,Franciszka Strzelczyka
+0941984,21433,Stuska,Franciszka Stuska
+0221936,21475,Styczyńskiego,Jana Styczyńskiego
+0062478,21852,Szczotki,Józefa Szczotki
+0939409,21937,Szewczyka,Wilhelma Szewczyka
+0214066,22288,Ściegiennego,Piotra Ściegiennego
+0945491,22291,Piotra Ściegiennego,Księdza Piotra Ściegiennego
+0941984,22385,Śniadeckiego,Jędrzeja Śniadeckiego
+0939094,22773,Kazimierza Tetmajera-Przerwy,Kazimierza Przerwy-Tetmajera
+0942297,22773,Kazimierza Tetmajera-Przerwy,Kazimierza Przerwy-Tetmajera
+0927091,22823,Osiedle Tokarnia,Tokarnia
+0942417,22961,Traugutta,Romualda Traugutta
+0215433,23030,Trulleya,Jana Trulleya
+0927091,23444,Osiedle Uścieńków,Uścieńków
+0214362,24320,Wilsona,Thomasa Woodrowa Wilsona
+0940849,24320,Wilsona,Thomasa Woodrowa Wilsona
+0927091,24842,Osiedle Wróblonki,Wróblonki
+0942765,25353,Zagłoby,Jana Onufrego Zagłoby
+0215427,25817,Zawadzkiego,Tadeusza Zawadzkiego
+0990511,25817,Zawadzkiego,Tadeusza Zawadzkiego
+0214327,26037,Zgrzebnioka,Alfonsa Zgrzebnioka
+0931678,26525,Hetmana Żółkiewskiego,Hetmana Stanisława Żółkiewskiego
+0939094,26608,Żwirki i Wigury,Franciszka Żwirki i Stanisława Wigury
+0926996,26608,Żwirki i Wigury,Franciszka Żwirki i Stanisława Wigury
+0213925,26608,Żwirki i Wigury,Franciszka Żwirki i Stanisława Wigury
+0944853,26608,Żwirki i Wigury,Franciszka Żwirki i Stanisława Wigury
+0945491,26608,Żwirki i Wigury,Franciszka Żwirki i Stanisława Wigury
+0942765,26983,Karola Chodkiewicza,Jana Karola Chodkiewicza
+0942765,28484,Kamila Baczyńskiego,Krzysztofa Kamila Baczyńskiego
+0221936,30474,Generała Bema,Józefa Bema
+0942765,31395,Ursyna Niemcewicza,Juliana Ursyna Niemcewicza
+0941139,33784,Kardynała Wyszyńskiego,Kardynała Stefana Wyszyńskiego
+0942765,33924,Kowalczyka,Jana Kowalczyka
+0130850,33975,Plac Kościuszki,Plac Tadeusza Kościuszki
+0931862,34141,Generała Andersa,Generała Władysława Andersa
+0214592,37683,Generała Sikorskiego,Generała Władysława Sikorskiego
+0059921,37683,Generała Sikorskiego,Generała Władysława Sikorskiego
+0219566,37694,Marszałka Piłsudskiego,Marszałka Józefa Piłsudskiego
+0062478,37694,Marszałka Piłsudskiego,Marszałka Józefa Piłsudskiego
+0942222,38377,Generała Hallera,Generała Józefa Hallera
+0217484,39618,Szymborskiej,Wisławy Szymborskiej
+0136509,39618,Szymborskiej,Wisławy Szymborskiej
+0943121,40259,Osiedle na Wzgórzu,Osiedle Na Wzgórzu
+0138649,41182,Plac Mickiewicza,Plac Adama Mickiewicza
+0927642,41889,Osiedle Kopernika,Osiedle Mikołaja Kopernika
+0932413,42217,Księdza Ściegiennego,Piotra Ściegiennego
+0059559,43009,Księdza Marszałka,Księdza Jana Marszałka
+0927642,44098,Aleja Piłsudskiego,Aleja Marszałka Józefa Piłsudskiego
+0059826,44187,Księdza Nowaka,Księdza Jana Nowaka
+0059826,44188,Księdza Stojałowskiego,Księdza Stanisława Stojałowskiego
+0939409,44285,Biskupa Pluty,Wilhelma Pluty
+0939409,44286,Księdza Pojdy,Księdza Adolfa Pojdy
+0213960,44286,Księdza Pojdy,Księdza Jana Pojdy
+0931862,45134,Generała Fieldorfa-Nila,Generała Augusta Emila Fieldorfa-Nila
+0073499,47065,Księdza Dziekana Józefa Pułki,Księdza Józefa Pułki
+0073499,47066,Księdza Prałata Piotrowskiego,Księdza Prałata Józefa Piotrowskiego
+0215597,47845,Księdza Gregora,Księdza Józefa Gregora
+0214327,47868,Księdza Roboty,Księdza Władysława Roboty
+0214362,47870,Księdza Pogrzeby,Księdza Franciszka Pogrzeby
+0931945,48034,Marii Curie Skłodowskiej,Marii Skłodowskiej-Curie
+0931862,48288,Księdza Muznerowskiego,Księdza Stanisława Muznerowskiego
+0941748,51287,Plac Piłsudskiego,Plac Józefa Piłsudskiego
+0944853,52220,świętego Wawrzyńca,Świętego Wawrzyńca
+0999765,52738,Księdza Janika,Księdza Pawła Janika
+0221994,53653,Raska,Józefa Raska
+0075216,55618,mjr Kazimierza Czarkowskiego,Majora Kazimierza Czarkowskiego
+0931945,56759,74-go Górnośląskiego Pułku Piechoty,74 Górnośląskiego Pułku Piechoty
+0939473,60296,Porozumienia Dąbrowskiego 1980,Porozumienia Dąbrowskiego 1980 roku


### PR DESCRIPTION
Mapowanie ulic w powiatach: rybnickim, mikołowskim, raciborskim, kłobuckim, cieszyńskim, pszczyńskim, lublinieckim, częstochowskim, gliwickim, zawierciańskim, wodzisławskim, bielskim, żywieckim, Dąbrowa Górnicza oraz Rybnik.